### PR TITLE
Switch `pkcs11` crate for `cryptoki` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoki"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcf151ec0f80b3798687640a731829fee41723e5850eb75bc860c106f2dbfc2"
+dependencies = [
+ "cryptoki-sys",
+ "derivative",
+ "libloading",
+ "log",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a426b46cbf8e98cea0209767e5c601199369c593d83466ffbc541ac4e0a15f52"
+dependencies = [
+ "libloading",
+ "target-lexicon",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -252,9 +286,9 @@ name = "keyls"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cryptoki",
  "hex",
  "kmip-protocol",
- "pkcs11",
  "prettytable-rs",
  "structopt",
 ]
@@ -307,11 +341,11 @@ checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
- "cc",
+ "cfg-if",
  "winapi",
 ]
 
@@ -342,36 +376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "300.0.4+3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e1c6b4549e24182b9d7aa268f645414888a69daf44c7b2d8118da8e7b23e7"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,18 +413,9 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "pkcs11"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aca6d67e4c8613bfe455599d0233d00735f85df2001f6bfd9bb7ac0496b10af"
-dependencies = [
- "libloading",
- "num-bigint",
 ]
 
 [[package]]
@@ -527,6 +531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "secrecy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +611,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "term"
@@ -693,3 +712,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.45"
 hex = "0.4.3"
-kmip = { package = "kmip-protocol", version = "0.4.1", features = ["tls-with-openssl"] }
-pkcs11 = "0.5.0"
+kmip = { package = "kmip-protocol", version = "0.4.1", features = ["tls-with-openssl-vendored"] }
+cryptoki = "0.2.0"
 prettytable-rs = "0.8.0"
 structopt = "0.3.25"

--- a/src/pkcs11client.rs
+++ b/src/pkcs11client.rs
@@ -23,7 +23,7 @@ pub(crate) fn get_keys(opt: Opt) -> Result<Vec<Key>> {
         let slot = get_slot(&pkcs11, server_opt)?;
         println!("Using PKCS#11 slot id {} ({:#x})", slot.id(), slot.id());
         if let Some(pin) = &server_opt.user_pin {
-            pkcs11.set_pin(slot, &pin)?;
+            pkcs11.set_pin(slot, pin)?;
         }
 
         let mut flags = Flags::new();
@@ -123,7 +123,7 @@ fn get_slot(pkcs11: &Pkcs11, server_opt: &Pkcs11ServerOpt) -> Result<Slot> {
     fn has_token_label(pkcs11: &Pkcs11, slot: Slot, slot_label: &str) -> bool {
         pkcs11
             .get_token_info(slot)
-            .map(|info| String::from_utf8_lossy(&info.label).trim_end().to_string() == slot_label)
+            .map(|info| String::from_utf8_lossy(&info.label).trim_end() == slot_label)
             .unwrap_or(false)
     }
 
@@ -132,7 +132,7 @@ fn get_slot(pkcs11: &Pkcs11, server_opt: &Pkcs11ServerOpt) -> Result<Slot> {
             match pkcs11
                 .get_all_slots()?
                 .into_iter()
-                .find(|&slot| slot.id() == (*id).into())
+                .find(|&slot| slot.id() == *id)
             {
                 Some(slot) => slot,
                 None => bail!("Cannot find slot wiht id {}", id),


### PR DESCRIPTION
This PR switches the `pkcs11` crate dependency for the `cryptoki` crate dependency instead.

In my testing on a Raspberry Pi 4b this resolves issue #4 "Unknown error code on ARMv7".

For background on the origins of the `cryptoki` crate and why it was created to replace the `pkcs11` crate see [here](https://github.com/NLnetLabs/krill/pull/727#issuecomment-974881030) and [here](https://github.com/mheese/rust-pkcs11/pull/43#issuecomment-784993292).